### PR TITLE
Make Dial method configurable through socks5.Config

### DIFF
--- a/request.go
+++ b/request.go
@@ -130,7 +130,8 @@ func (s *Server) handleConnect(conn conn, bufConn io.Reader, dest, realDest *Add
 
 	// Attempt to connect
 	addr := net.TCPAddr{IP: realDest.IP, Port: realDest.Port}
-	target, err := net.DialTCP("tcp", nil, &addr)
+	target, err := net.Dial("tcp", addr.String())
+
 	if err != nil {
 		msg := err.Error()
 		resp := hostUnreachable

--- a/request.go
+++ b/request.go
@@ -130,7 +130,7 @@ func (s *Server) handleConnect(conn conn, bufConn io.Reader, dest, realDest *Add
 
 	// Attempt to connect
 	addr := net.TCPAddr{IP: realDest.IP, Port: realDest.Port}
-	target, err := net.Dial("tcp", addr.String())
+	target, err := s.config.ConnectFunc("tcp", addr.String())
 
 	if err != nil {
 		msg := err.Error()

--- a/request_test.go
+++ b/request_test.go
@@ -48,8 +48,9 @@ func TestRequest_Connect(t *testing.T) {
 
 	// Make server
 	s := &Server{config: &Config{
-		Rules:    PermitAll(),
-		Resolver: DNSResolver{},
+		Rules:       PermitAll(),
+		Resolver:    DNSResolver{},
+		ConnectFunc: net.Dial,
 	}}
 
 	// Create the connect request
@@ -117,8 +118,9 @@ func TestRequest_Connect_RuleFail(t *testing.T) {
 
 	// Make server
 	s := &Server{config: &Config{
-		Rules:    PermitNone(),
-		Resolver: DNSResolver{},
+		Rules:       PermitNone(),
+		Resolver:    DNSResolver{},
+		ConnectFunc: net.Dial,
 	}}
 
 	// Create the connect request

--- a/socks5.go
+++ b/socks5.go
@@ -11,6 +11,8 @@ const (
 	socks5Version = uint8(5)
 )
 
+type Connector func(net, address string) (net.Conn, error)
+
 // Config is used to setup and configure a Server
 type Config struct {
 	// AuthMethods can be provided to implement custom authentication
@@ -38,6 +40,10 @@ type Config struct {
 
 	// BindIP is used for bind or udp associate
 	BindIP net.IP
+
+	// ConnectFunc may be used as function which establishes connection
+	// with remote host while request handling
+	ConnectFunc Connector
 }
 
 // Server is reponsible for accepting connections and handling
@@ -66,6 +72,10 @@ func New(conf *Config) (*Server, error) {
 	// Ensure we have a rule set
 	if conf.Rules == nil {
 		conf.Rules = PermitAll()
+	}
+
+	if conf.ConnectFunc == nil {
+		conf.ConnectFunc = net.Dial
 	}
 
 	server := &Server{


### PR DESCRIPTION
Hi,

Today I tried to implement 'ssh -D' behavior using github.com/armon/go-socks5 and golang.org/x/crypto/ssh libraries. As you may know ssh.Client implements the interface which allows to create tunneled connections https://godoc.org/golang.org/x/crypto/ssh#Client.Dial

socks5 package uses net.DialTCP function to establish connection with remote host. It's ok, and it returns *net.TCPConn as a result. We don't use any specific features of net.TCPConn interface, so, it may be reduced to net.Conn by using net.Dial instead of net.DialTCP. Why do we need this changes?

On the other side ssh.Client.Dial and ssh.Client.DialTCP methods differs only by accepted arguments. Returning values are the same (net.Conn, error). And we can not "extend" net.Conn to net.TCPConn in our code.

So, short answer for the question in second paragraph is "for interoperability between socks5 package and others". I guess since we don't use net.TCPConn features, we can replace it with net.Conn and make connection function configurable through socks5.Config.

Commit message in b0c2980 contains example of how it can be used.