### PR TITLE
corrected Serve() unreachable code in socks5.go

### DIFF
--- a/socks5.go
+++ b/socks5.go
@@ -2,11 +2,12 @@ package socks5
 
 import (
 	"bufio"
-	"context"
 	"fmt"
 	"log"
 	"net"
 	"os"
+
+	"golang.org/x/net/context"
 )
 
 const (

--- a/socks5.go
+++ b/socks5.go
@@ -50,7 +50,7 @@ type Config struct {
 	Dial func(ctx context.Context, network, addr string) (net.Conn, error)
 }
 
-// Server is reponsible for accepting connections and handling
+// Server is responsible for accepting connections and handling
 // the details of the SOCKS5 protocol
 type Server struct {
 	config      *Config
@@ -116,6 +116,8 @@ func (s *Server) Serve(l net.Listener) error {
 		go func(net.Conn) {
 			if err := s.ServeConn(conn); err != nil {
 				errChan <- err
+			} else {
+				errChan <- nil
 			}
 		}(conn)
 		return <-errChan

--- a/socks5.go
+++ b/socks5.go
@@ -2,12 +2,11 @@ package socks5
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"log"
 	"net"
 	"os"
-
-	"golang.org/x/net/context"
 )
 
 const (
@@ -113,7 +112,7 @@ func (s *Server) Serve(l net.Listener) error {
 		if err != nil {
 			return err
 		}
-		go func(Conn) {
+		go func(net.Conn) {
 			if err := s.ServeConn(conn); err != nil {
 				errChan <- err
 			}

--- a/socks5.go
+++ b/socks5.go
@@ -107,14 +107,19 @@ func (s *Server) ListenAndServe(network, addr string) error {
 
 // Serve is used to serve connections from a listener
 func (s *Server) Serve(l net.Listener) error {
+	errChan := make(chan error)
 	for {
 		conn, err := l.Accept()
 		if err != nil {
 			return err
 		}
-		go s.ServeConn(conn)
+		go func(Conn) {
+			if err := s.ServeConn(conn); err != nil {
+				errChan <- err
+			}
+		}(conn)
+		return <-errChan
 	}
-	return nil
 }
 
 // ServeConn is used to serve a single connection.


### PR DESCRIPTION
running Vet indicated an unreachable code in Serve().

I propose this correction, a simple remove of the 'return nil' could do as well.