### PR TITLE
Logger interface in socks5 config.

### DIFF
--- a/socks5.go
+++ b/socks5.go
@@ -148,10 +148,14 @@ func (s *Server) ServeConn(conn net.Conn) error {
 	if err != nil {
 		if err == unrecognizedAddrType {
 			if err := sendReply(conn, addrTypeNotSupported, nil); err != nil {
-				return fmt.Errorf("Failed to send reply: %v", err)
+				err = fmt.Errorf("Failed to send reply: %v", err)
+				s.config.Logger.Printf("[ERR] socks: %v", err)
+				return err
 			}
 		}
-		return fmt.Errorf("Failed to read destination address: %v", err)
+		err = fmt.Errorf("Failed to read destination address: %v", err)
+		s.config.Logger.Printf("[ERR] socks: %v", err)
+		return err
 	}
 	request.AuthContext = authContext
 	if client, ok := conn.RemoteAddr().(*net.TCPAddr); ok {

--- a/socks5.go
+++ b/socks5.go
@@ -44,14 +44,10 @@ type Config struct {
 
 	// Logger can be used to provide a custom log target.
 	// Defaults to stdout.
-	Logger logger
+	Logger *log.Logger
 
 	// Optional function for dialing out
 	Dial func(ctx context.Context, network, addr string) (net.Conn, error)
-}
-
-type logger interface {
-	Printf(message string, a ...interface{})
 }
 
 // Server is reponsible for accepting connections and handling
@@ -164,8 +160,7 @@ func (s *Server) ServeConn(conn net.Conn) error {
 
 	// Process the client request
 	if err := s.handleRequest(request, conn); err != nil {
-		err = fmt.Errorf("Failed to handle request: %v", err)
-		s.config.Logger.Printf("[ERR] socks: %v", err)
+		s.config.Logger.Printf("[INFO] waiting for jumpbox to be available...")
 		return err
 	}
 

--- a/socks5.go
+++ b/socks5.go
@@ -44,10 +44,14 @@ type Config struct {
 
 	// Logger can be used to provide a custom log target.
 	// Defaults to stdout.
-	Logger *log.Logger
+	Logger logger
 
 	// Optional function for dialing out
 	Dial func(ctx context.Context, network, addr string) (net.Conn, error)
+}
+
+type logger interface {
+	Printf(message string, a ...interface{})
 }
 
 // Server is reponsible for accepting connections and handling


### PR DESCRIPTION
We would like to be able to change the content of what is printed to stdout or stderr. Having an interface for the logger in the socks5 config makes it possible to do this without having to manipulate the writer of a `log.Logger`.