### PR TITLE
Remove x/net/context dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: go
 go:
-  - 1.1
+  - 1.7
   - tip

--- a/request.go
+++ b/request.go
@@ -1,13 +1,12 @@
 package socks5
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
 	"strconv"
 	"strings"
-
-	"golang.org/x/net/context"
 )
 
 const (

--- a/resolver.go
+++ b/resolver.go
@@ -1,9 +1,8 @@
 package socks5
 
 import (
+	"context"
 	"net"
-
-	"golang.org/x/net/context"
 )
 
 // NameResolver is used to implement custom name resolution

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -1,9 +1,8 @@
 package socks5
 
 import (
+	"context"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestDNSResolver(t *testing.T) {

--- a/ruleset.go
+++ b/ruleset.go
@@ -1,7 +1,7 @@
 package socks5
 
 import (
-	"golang.org/x/net/context"
+	"context"
 )
 
 // RuleSet is used to provide custom rules to allow or prohibit actions

--- a/ruleset_test.go
+++ b/ruleset_test.go
@@ -1,9 +1,8 @@
 package socks5
 
 import (
+	"context"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestPermitCommand(t *testing.T) {

--- a/socks5.go
+++ b/socks5.go
@@ -2,12 +2,11 @@ package socks5
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"log"
 	"net"
 	"os"
-
-	"golang.org/x/net/context"
 )
 
 const (


### PR DESCRIPTION
Since go 1.7 context is built into standard library. I replaced imports with "context" so your library won't have any external dependencies. Also I bumped minimal go version in travis config to 1.7.